### PR TITLE
MAINT: Add book pdf as a local download asset

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,6 +80,11 @@ jobs:
           cp -r frontpage/assets _build/html/
           cp -r frontpage/images _build/html/
           cp frontpage/index.html _build/html/
+      - name: Book PDF
+        shell: bash -l {0}
+        run: |
+          mkdir -p _build/html/_downloads
+          cp pdf/networks.pdf _build/html/_downloads/
       - name: Save Build as Artifact
         uses: actions/upload-artifact@v1
         with:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -90,6 +90,11 @@ jobs:
           cp -r frontpage/assets _build/html/
           cp -r frontpage/images _build/html/
           cp frontpage/index.html _build/html/
+      - name: Book PDF
+        shell: bash -l {0}
+        run: |
+          mkdir -p _build/html/_downloads
+          cp pdf/networks.pdf _build/html/_downloads/
       - name: Deploy website to gh-pages
         uses: peaceiris/actions-gh-pages@v3
         with:

--- a/README.md
+++ b/README.md
@@ -3,3 +3,7 @@
 Companion Site for Economic Networks: Theory and Computation
 
 https://networks.quantecon.org
+
+## PDF
+
+To update the PDF replace the `networks.pdf` file in the `pdf` folder.

--- a/frontpage/index.html
+++ b/frontpage/index.html
@@ -24,7 +24,7 @@
 							<h1>Economic Networks</h1>
 							<h2>Theory and Computation</h2>
 							<p><a href="http://johnstachurski.net">John Stachurski</a> and <a href="http://www.tomsargent.com">Thomas J. Sargent</a></p>
-							<p>Download the textbook <a href="https://arxiv.org/pdf/2203.11972.pdf">here</a></p>
+							<p>Download the textbook <a href="_downloads/networks.pdf" download>here</a></p>
 							<ul class="actions">
 								<li><a href="#first" class="arrow scrolly"><span class="label">Next</span></a></li>
 							</ul>


### PR DESCRIPTION
This PR adds the `pdf` as a local download asset rather than use `arXiv`

- [x] add `publish.yml` workflow to position the asset from the `pdf` folder (for easy updating)
- [x] update `README`