### PR TITLE
MAINT: Update to use matplotlib config from package

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,20 @@ jobs:
           python-version: 3.8
           environment-file: environment.yml
           activate-environment: networks
+      - name: Install latex dependencies
+        run: |
+          sudo apt-get -qq update
+          sudo apt-get install -y     \
+            texlive-latex-recommended \
+            texlive-latex-extra       \
+            texlive-fonts-recommended \
+            texlive-fonts-extra       \
+            texlive-xetex             \
+            latexmk                   \
+            xindy                     \
+            dvipng                    \
+            cm-super                  \
+            msttcorefonts
       - name: Set up Julia
         uses: julia-actions/setup-julia@v1
         with:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -21,6 +21,20 @@ jobs:
           python-version: 3.8
           environment-file: environment.yml
           activate-environment: networks
+      - name: Install latex dependencies
+        run: |
+          sudo apt-get -qq update
+          sudo apt-get install -y     \
+            texlive-latex-recommended \
+            texlive-latex-extra       \
+            texlive-fonts-recommended \
+            texlive-fonts-extra       \
+            texlive-xetex             \
+            latexmk                   \
+            xindy                     \
+            dvipng                    \
+            cm-super                  \
+            msttcorefonts
       - name: Set up Julia
         uses: julia-actions/setup-julia@v1
         with:

--- a/code_book/ch_opt.md
+++ b/code_book/ch_opt.md
@@ -26,6 +26,7 @@ We begin with some imports
 
 ```{code-cell}
 import quantecon as qe
+import quantecon_book_networks
 import quantecon_book_networks.input_output as qbn_io
 import quantecon_book_networks.plotting as qbn_plt
 import quantecon_book_networks.data as qbn_data
@@ -40,7 +41,8 @@ import ot
 import matplotlib.pyplot as plt
 from matplotlib import cm
 from matplotlib.patches import Polygon
-from matplotlib.artist import Artist  
+from matplotlib.artist import Artist
+quantecon_book_networks.config("matplotlib")
 ```
 
 ## Linear Programming and Duality


### PR DESCRIPTION
This PR updates the code_book to use

```
quantecon_book_networks.config("matplotlib")
```

https://github.com/QuantEcon/quantecon-book-networks/pull/1

@shlff would you mind updating this PR with the changes once the above is merged and released on PyPI