### PR TITLE
[MAINT] Fix Link Reference to dp-book1 and Missing Link to Code Book

### DIFF
--- a/frontpage/index.html
+++ b/frontpage/index.html
@@ -92,7 +92,7 @@
 						<div class="content">
 							<ul class="actions fit">
 								<li>
-									<a href="https://github.com/QuantEcon/book-networks/tree/main/code_book" class="button fit"><img src="images/logo-square.svg" width="13"><span style="margin-left:10px">Code Book</span></a>
+									<a href="intro.html" class="button fit"><img src="images/logo-square.svg" width="13"><span style="margin-left:10px">Code Book</span></a>
 								</li>
 								<li>
 									<a href="https://github.com/QuantEcon/book-networks" class="button fit"><img src="images/github-mark.png" width="10"><span style="margin-left:10px">GitHub</span></a>

--- a/frontpage/index.html
+++ b/frontpage/index.html
@@ -92,7 +92,7 @@
 						<div class="content">
 							<ul class="actions fit">
 								<li>
-									<a href="https://github.com/QuantEcon/quantecon-book-networks" class="button fit"><img src="images/logo-square.svg" width="13"><span style="margin-left:10px">Code Book</span></a>
+									<a href="https://github.com/QuantEcon/book-networks/tree/main/code_book" class="button fit"><img src="images/logo-square.svg" width="13"><span style="margin-left:10px">Code Book</span></a>
 								</li>
 								<li>
 									<a href="https://github.com/QuantEcon/book-networks" class="button fit"><img src="images/github-mark.png" width="10"><span style="margin-left:10px">GitHub</span></a>

--- a/frontpage/index.html
+++ b/frontpage/index.html
@@ -92,7 +92,7 @@
 						<div class="content">
 							<ul class="actions fit">
 								<li>
-									<a href="intro.html" class="button fit"><img src="images/logo-square.svg" width="13"><span style="margin-left:10px">Code Book</span></a>
+									<a href="https://github.com/QuantEcon/quantecon-book-networks" class="button fit"><img src="images/logo-square.svg" width="13"><span style="margin-left:10px">Code Book</span></a>
 								</li>
 								<li>
 									<a href="https://github.com/QuantEcon/book-networks" class="button fit"><img src="images/github-mark.png" width="10"><span style="margin-left:10px">GitHub</span></a>

--- a/frontpage/index.html
+++ b/frontpage/index.html
@@ -95,7 +95,7 @@
 									<a href="intro.html" class="button fit"><img src="images/logo-square.svg" width="13"><span style="margin-left:10px">Code Book</span></a>
 								</li>
 								<li>
-									<a href="https://github.com/QuantEcon/book-dp1/" class="button fit"><img src="images/github-mark.png" width="10"><span style="margin-left:10px">GitHub</span></a>
+									<a href="https://github.com/QuantEcon/book-networks" class="button fit"><img src="images/github-mark.png" width="10"><span style="margin-left:10px">GitHub</span></a>
 								</li>
 							</ul>
 							<ul class="actions fit">


### PR DESCRIPTION
Hi @jstac,

This PR addresses the link issue in [#11 in dp-book1](https://github.com/QuantEcon/book-dp1/issues/11).

The icon will now direct to this repo.

It also fixes the link to the [code book](https://github.com/QuantEcon/book-networks/tree/main/code_book) which is currently missing.

Please kindly review the change and merge if it looks good to you. A preview can be found [here](https://deploy-preview-49--keen-wozniak-c08666.netlify.app/frontpage/) for your review.

Many thanks.