### PR TITLE
MAINT: Upgrade Julia and Python

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
           auto-update-conda: true
           auto-activate-base: true
           miniconda-version: 'latest'
-          python-version: 3.8
+          python-version: 3.11
           environment-file: environment.yml
           activate-environment: networks
       - name: Install latex dependencies
@@ -32,7 +32,7 @@ jobs:
       - name: Set up Julia
         uses: julia-actions/setup-julia@v1
         with:
-          version: 1.7.2
+          version: 1.9
       - name: Install IJulia and Setup Project
         shell: bash
         run: |

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -18,7 +18,7 @@ jobs:
           auto-update-conda: true
           auto-activate-base: true
           miniconda-version: 'latest'
-          python-version: 3.8
+          python-version: 3.11
           environment-file: environment.yml
           activate-environment: networks
       - name: Install latex dependencies
@@ -38,7 +38,7 @@ jobs:
       - name: Set up Julia
         uses: julia-actions/setup-julia@v1
         with:
-          version: 1.7.2
+          version: 1.9
       - name: Install IJulia and Setup Project
         shell: bash
         run: |

--- a/code_book/_toc.yml
+++ b/code_book/_toc.yml
@@ -2,7 +2,7 @@ format: jb-book
 root: intro
 chapters:
 - url: https://networks.quantecon.org
-  title: Home (Landing Page)
+  title: Home
 - file: ch_intro
 - file: ch_production
 - file: ch_opt
@@ -11,3 +11,4 @@ chapters:
 - file: ch_fpms
 - file: appendix
 - file: pkg_funcs
+- file: status

--- a/code_book/status.md
+++ b/code_book/status.md
@@ -1,0 +1,17 @@
+---
+jupytext:
+  text_representation:
+    extension: .md
+    format_name: myst
+kernelspec:
+  display_name: Python 3
+  language: python
+  name: python3
+---
+
+# Execution Statistics
+
+This table contains the latest execution statistics.
+
+```{nb-exec-table}
+```

--- a/environment.yml
+++ b/environment.yml
@@ -1,20 +1,19 @@
-name: networks
+name: quantecon
 channels:
   - default
 dependencies:
-  - python=3.8
-  - anaconda=2021.11
+  - python=3.11
+  - anaconda=2023.09
   - pip
   - pip:
-    - jupyter-book==0.12.1
-    - quantecon-book-theme==0.3.0
-    - sphinx-tojupyter==0.2.0
+    - jupyter-book==0.15.1
+    - docutils==0.17.1
+    - quantecon-book-theme==0.6.0
+    - sphinx-tojupyter==0.3.0
     - sphinxext-rediraffe==0.2.7
-    - sphinx-exercise==0.2.1
-    - quantecon
-    - pandas-datareader
-    - POT==0.8.1
-    - plotly
-    - interpolation
-    - sphinx-design
-    - quantecon_book_networks
+    - sphinx-exercise==0.4.1
+    - ghp-import==2.1.0
+    - sphinxcontrib-youtube==1.2.0
+    - sphinx-togglebutton==0.3.2
+    - arviz==0.13.0
+    - kaleido


### PR DESCRIPTION
This PR

- upgrades to `julia=1.9`
- upgrades to `python=3.11`
- uses latest anaconda